### PR TITLE
Compatibility with Rails >=5.1

### DIFF
--- a/app/controllers/issue_attachment_queries_controller.rb
+++ b/app/controllers/issue_attachment_queries_controller.rb
@@ -22,8 +22,8 @@
 class IssueAttachmentQueriesController < ApplicationController
   #menu_item :issue_attachments
   menu_item :issue_attachments
-  before_filter :find_query, :except => [:new, :create, :index]
-  before_filter :find_optional_project, :only => [:new, :create, :index]
+  before_action :find_query, :except => [:new, :create, :index]
+  before_action :find_optional_project, :only => [:new, :create, :index]
 
   accept_api_auth :index
 

--- a/app/controllers/issue_attachments_controller.rb
+++ b/app/controllers/issue_attachments_controller.rb
@@ -25,8 +25,8 @@ require 'zip'
 class IssueAttachmentsController < AttachmentsController
 
 
-  before_filter :find_optional_project,  :only => [:index]
-  before_filter :find_issue_attachments, :only => [:issue_attachments_menu, :bulk_pdf, :bulk_zip, :bulk_delete, :bulk_categorize]
+  before_action :find_optional_project,  :only => [:index]
+  before_action :find_issue_attachments, :only => [:issue_attachments_menu, :bulk_pdf, :bulk_zip, :bulk_delete, :bulk_categorize]
   before_action :authorize
 
   helper :issue_attachment_queries


### PR DESCRIPTION
before_filter was deprecated then in Rails 5.1 the function was removed. switch to using before_action.